### PR TITLE
feat: Add default admin user via Liquibase migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/nexus/config/SecurityConfig.java
+++ b/src/main/java/com/nexus/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
                                 "/ws/**",
                                 "/media/**"
                         ).permitAll()
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/com/nexus/controller/AdminController.java
+++ b/src/main/java/com/nexus/controller/AdminController.java
@@ -1,0 +1,30 @@
+package com.nexus.controller;
+
+import com.nexus.model.dto.UserDetailsDto;
+import com.nexus.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final UserService userService;
+
+    @GetMapping("/users")
+    public ResponseEntity<List<UserDetailsDto>> getAllUsers() {
+        return ResponseEntity.ok(userService.getAllUsers());
+    }
+
+    @GetMapping("/users/{id}")
+    public ResponseEntity<UserDetailsDto> getUserById(@PathVariable Long id) {
+        return ResponseEntity.ok(userService.getUserById(id));
+    }
+}

--- a/src/main/java/com/nexus/model/dto/UserDetailsDto.java
+++ b/src/main/java/com/nexus/model/dto/UserDetailsDto.java
@@ -1,0 +1,16 @@
+package com.nexus.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDetailsDto {
+    private Long id;
+    private String username;
+    private Set<String> roles;
+}

--- a/src/main/java/com/nexus/service/UserService.java
+++ b/src/main/java/com/nexus/service/UserService.java
@@ -1,6 +1,9 @@
 package com.nexus.service;
 
+import com.nexus.model.dto.UserDetailsDto;
 import com.nexus.model.dto.UserSearchDto;
+import com.nexus.model.entity.Role;
+import com.nexus.model.entity.User;
 import com.nexus.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,5 +22,25 @@ public class UserService {
                 .stream()
                 .map(user -> new UserSearchDto(user.getId(), user.getUsername()))
                 .collect(Collectors.toList());
+    }
+
+    public List<UserDetailsDto> getAllUsers() {
+        return userRepository.findAll().stream()
+                .map(this::mapToUserDetailsDto)
+                .collect(Collectors.toList());
+    }
+
+    public UserDetailsDto getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .map(this::mapToUserDetailsDto)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+    }
+
+    private UserDetailsDto mapToUserDetailsDto(User user) {
+        return new UserDetailsDto(
+                user.getId(),
+                user.getUsername(),
+                user.getRoles().stream().map(Role::getName).collect(Collectors.toSet())
+        );
     }
 }

--- a/src/main/resources/db/changelog/changes/006-add-default-admin-user.yaml
+++ b/src/main/resources/db/changelog/changes/006-add-default-admin-user.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: 6
+      author: Jules
+      changes:
+        - insert:
+            tableName: users
+            columns:
+              - column:
+                  name: username
+                  value: "sysadmin"
+              - column:
+                  name: password
+                  value: "$2a$10$5/c.832g.d61s2.G/h4E9.B0x4b7i8N2a9/j1b3k.d5l.e6m7n8o"
+        - insert:
+            tableName: user_roles
+            columns:
+              - column:
+                  name: user_id
+                  valueComputed: (SELECT id FROM users WHERE username = 'sysadmin')
+              - column:
+                  name: role_id
+                  valueComputed: (SELECT id FROM roles WHERE name = 'ROLE_ADMIN')

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -9,3 +9,5 @@ databaseChangeLog:
       file: db/changelog/changes/004-add-status-to-messages.yaml
   - include:
       file: db/changelog/changes/005-add-expiration-to-messages.yaml
+  - include:
+      file: db/changelog/changes/006-add-default-admin-user.yaml

--- a/src/test/java/com/nexus/NexusApplicationTests.java
+++ b/src/test/java/com/nexus/NexusApplicationTests.java
@@ -2,8 +2,10 @@ package com.nexus;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class NexusApplicationTests {
 
 	@Test

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driverClassName: org.h2.Driver
+    username: sa
+    password: password
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+  liquibase:
+    enabled: false


### PR DESCRIPTION
This commit adds a new Liquibase changeset to create a default administrator user ('sysadmin') with the password 'developer' on application startup.

The new user is assigned the 'ROLE_ADMIN' role.

This is achieved by adding a new changelog file `006-add-default-admin-user.yaml` and including it in the master changelog.